### PR TITLE
[ISSUE-20] Update CD workflow to check package with different python versions

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -7,16 +7,21 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  autorelease:
-    name: Release package
+  checks:
+    name: check package to be released
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         os:
           - 'ubuntu-latest'
+          #- 'macos-latest'
+          #- 'windows-latest'
         python-version:
           - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
@@ -27,23 +32,9 @@ jobs:
           python-version: ${{matrix.python-version}}
           architecture: x64
 
-      - name: Build source and binary distributions
+      - name: Build source distribution
         shell: bash -l {0}
-        run: |
-          python -m pip install build wheel
-          python setup.py sdist bdist_wheel
-
-      - name: Add version to environment vars
-        run: |
-          PROJECT_VERSION=$(python setup.py --version)
-          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
-
-      - name: Check if tag version matches project version
-        run: |
-          TAG=$(git describe HEAD --tags --abbrev=0)
-          echo $TAG
-          echo $PROJECT_VERSION
-          if [[ "$TAG" != "v$PROJECT_VERSION" ]]; then exit 1; fi
+        run: make install
 
       - name: Check source package structure
         run: |
@@ -71,14 +62,42 @@ jobs:
           rm -rf $DIR
 
       - name: Check typing, linting and formatting
+        run: make checks
+
+  autorelease:
+    name: release the package on PyPI
+    needs: checks
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.3.4
+
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '3.7'
+          architecture: x64
+
+      - name: Build source and binary distributions
+        shell: bash -l {0}
         run: |
-          python -m pip install -r requirements/requirements_dev.txt
-          python -m pip install $(ls -rt  dist/*.tar.gz | tail -1)
-          python -m black --check py4ai/core tests
-          python -m isort py4ai/core tests -c
-          python -m flake8 py4ai/core tests
-          python -m mypy --install-types --non-interactive --package py4ai --package tests
-          python -m pytest
+          python -m pip install build wheel
+          python setup.py sdist bdist_wheel
+
+      - name: Add version to environment vars
+        run: |
+          PROJECT_VERSION=$(python setup.py --version)
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+
+      - name: Check if tag version matches project version
+        run: |
+          TAG=$(git describe HEAD --tags --abbrev=0)
+          echo $TAG
+          echo $PROJECT_VERSION
+          if [[ "$TAG" != "v$PROJECT_VERSION" ]]; then exit 1; fi
 
       - name: Release Notes
         uses: heinrichreimer/github-changelog-generator-action@v2.3


### PR DESCRIPTION
Closes #20 

I separated the two jobs in the CD workflow to be allowed to check the packages with different python versions while performing only once the release steps.